### PR TITLE
adoptation for ghidra 9.3.0

### DIFF
--- a/Decompile_TEMPLATE.java
+++ b/Decompile_TEMPLATE.java
@@ -36,7 +36,7 @@ import ghidra.program.model.listing.Listing;
 import java.util.ArrayList;
 import java.io.FileWriter;
 
-public class Decompile extends HeadlessScript {
+public class Gnidja extends HeadlessScript {
 
 	@Override
 	public void run() throws Exception {

--- a/decompiler.py
+++ b/decompiler.py
@@ -6,7 +6,7 @@ import subprocess
 
 class Decompiler(BackgroundTaskThread):
     def __init__(self,file_name,current_path):
-        #self.progress_banner = f"[Ghinja] Running the decompiler job ... Ghinja decompiler output not available until finished."
+        self.progress_banner = f"[Ghinja] Running the decompiler job ... Ghinja decompiler output not available until finished."
         BackgroundTaskThread.__init__(self, "", True)
         self.file_name = str(Path(file_name).name)
         self.file_path = file_name
@@ -18,11 +18,12 @@ class Decompiler(BackgroundTaskThread):
         self.progress = f"[Ghinja] Running the decompiler job ... Ghinja decompiler output not available until finished."
         with open(os.path.dirname(os.path.realpath(__file__)) + "/Decompile_TEMPLATE.java",'r') as decomp_file:
             data = decomp_file.read()
-            with open(os.path.dirname(os.path.realpath(__file__)) + "/Decompile.java",'w') as tmp_decomp_file:
+            with open(os.path.dirname(os.path.realpath(__file__)) + "/Gnidja/Gnidja.java",'w') as tmp_decomp_file:
                 tmp_decomp_file.write(data.replace("PLACEHOLDER_OUTPUT",str(self.decompile_result_path).replace("\\","\\\\")))
-        os.system(f"{Settings().get_string('ghinja.ghidra_install_path')} \"{str(self.current_path)}\" \"{self.file_name}\" -import \"{self.file_path}\" -postscript Decompile.java -scriptPath \"{os.path.dirname(os.path.realpath(__file__))}\"")
-        #log_info(f"{Settings().get_string('ghinja.ghidra_install_path')} \"{str(self.current_path)}\" \"{self.file_name}\" -import \"{self.file_path}\" -postscript \"{os.path.dirname(os.path.realpath(__file__)) + '/Decompile.java'}\"")
-        
-        os.remove(os.path.dirname(os.path.realpath(__file__)) + "/Decompile.java")
+        os.system(f"{Settings().get_string('ghinja.ghidra_install_path')} \"{str(self.current_path)}\" \"{self.file_name}\" -import \"{self.file_path}\" -scriptPath \"{os.path.dirname(os.path.realpath(__file__)) + '/Gnidja'}\" -postScript \"Gnidja.java\"")
+        #os.system(f"{Settings().get_string('ghinja.ghidra_install_path')} \"{str(self.current_path)}\" \"{self.file_name}\" -import \"{self.file_path}\" -postscript Decompile.java -scriptPath \"{os.path.dirname(os.path.realpath(__file__))}\"")	#new
+        #os.system(f"{Settings().get_string('ghinja.ghidra_install_path')} \"{str(self.current_path)}\" \"{self.file_name}\" -import \"{self.file_path}\" -postscript \"{os.path.dirname(os.path.realpath(__file__)) + '/Decompile.java'}\"")		#combi
+        #log_info(f"{Settings().get_string('ghinja.ghidra_install_path')} \"{str(self.current_path)}\" \"{self.file_name}\" -import \"{self.file_path}\" -postscript \"/home/c4t/.binaryninja/plugins/ghinja/Decompile.java\"")
+        os.remove(os.path.dirname(os.path.realpath(__file__)) + "/Gnidja/Gnidja.java")
 
 


### PR DESCRIPTION
I wasn't able to use origin with ghidra 9.3.0, and prebuilded latest from official site getting next:
```
  (AutoAnalysisManager.java:1290) 
INFO  REPORT: Analysis succeeded for file: /opt/PWN/DK2021/tr1v4  (HeadlessAnalyzer.java:1018) 
ERROR Failed to find script in any script directory: /home/.binaryninja/plugins/ghinja/Decompile.java  (GhidraScriptUtil.java:138) 
ERROR REPORT SCRIPT ERROR: /home/.binaryninja/plugins/ghinja/Decompile.java : Failed to find source bundle containing script: /home/.binaryninja/plugins/ghinja/Decompile.java  (HeadlessAnalyzer.java:934) 
java.lang.ClassNotFoundException: Failed to find source bundle containing script: /home/.binaryninja/plugins/ghinja/Decompile.java
	at ghidra.app.script.JavaScriptProvider.loadClass(JavaScriptProvider.java:118) ~[Base.jar:?]
	at ghidra.app.script.JavaScriptProvider.getScriptInstance(JavaScriptProvider.java:81) ~[Base.jar:?]
	at ghidra.app.util.headless.HeadlessAnalyzer.runScriptsList(HeadlessAnalyzer.java:895) [Base.jar:?]
	at ghidra.app.util.headless.HeadlessAnalyzer.analyzeProgram(HeadlessAnalyzer.java:1057) [Base.jar:?]
	at ghidra.app.util.headless.HeadlessAnalyzer.processFileWithImport(HeadlessAnalyzer.java:1550) [Base.jar:?]
	at ghidra.app.util.headless.HeadlessAnalyzer.processWithImport(HeadlessAnalyzer.java:1688) [Base.jar:?]
	at ghidra.app.util.headless.HeadlessAnalyzer.processWithImport(HeadlessAnalyzer.java:1753) [Base.jar:?]
	at ghidra.app.util.headless.HeadlessAnalyzer.processLocal(HeadlessAnalyzer.java:445) [Base.jar:?]
	at ghidra.app.util.headless.AnalyzeHeadless.launch(AnalyzeHeadless.java:121) [Base.jar:?]
	at ghidra.GhidraLauncher.main(GhidraLauncher.java:82) [Utility.jar:?]
INFO  ANALYZING changes made by post scripts: /opt/PWN/DK2021/tr1v4  (HeadlessAnalyzer.java:1086) 
INFO  REPORT: Post-analysis succeeded for file: /opt/PWN/DK2021/tr1v4  (HeadlessAnalyzer.java:1094) 
INFO  REPORT: Save succeeded for file: /tr1v4  (HeadlessAnalyzer.java:1586) 

```